### PR TITLE
Add reset method

### DIFF
--- a/DataCollector/ClientDataCollector.php
+++ b/DataCollector/ClientDataCollector.php
@@ -96,4 +96,11 @@ class ClientDataCollector extends DataCollector
     {
         $this->transactions[$id] = $transaction;
     }
+    
+    /**
+     * Reset DataCollector to initial state.
+     */
+    public function reset() {
+        $this->transactions = [];   
+    }
 }


### PR DESCRIPTION
"Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since Symfony 3.4 and will be unsupported in 4.0 for class